### PR TITLE
fixed RAM settings (YJ-14015 support)

### DIFF
--- a/mitosis-keyboard-basic/custom/armgcc/gzll_gcc_nrf51.ld
+++ b/mitosis-keyboard-basic/custom/armgcc/gzll_gcc_nrf51.ld
@@ -6,7 +6,7 @@ GROUP(-lgcc -lc -lnosys)
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x0, LENGTH = 0x40000
-  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x8000
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x4000
 }
 
 SECTIONS


### PR DESCRIPTION
Fixed RAM settings for smaller nrf51822 modules (YJ-14015). I think it was a typo, because receiver had this fix already. Everything works now.