### PR TITLE
Change baud rate to 250k, which an 8Mhz pro micro can support.

### DIFF
--- a/mitosis-receiver-basic/main.c
+++ b/mitosis-receiver-basic/main.c
@@ -75,7 +75,7 @@ int main(void)
           CTS_PIN_NUMBER,
           APP_UART_FLOW_CONTROL_DISABLED,
           false,
-          UART_BAUDRATE_BAUDRATE_Baud1M
+          UART_BAUDRATE_BAUDRATE_Baud250000
       };
 
     APP_UART_FIFO_INIT(&comm_params,


### PR DESCRIPTION
I recently built a Mitosis keyboard, but I used a 8Mhz pro micro instead of the 16Mhz one by mistake.

If I understood the datasheet correctly, when running at 8Mhz the pro micro can't achieve 1M baudrate.

I was able to make it work with no apparent loss in functionality by changing the baud rate to 250k.

Since this seems to be adequate, it could be set this way by default and enable either flavor of pro micro board to be compatible with the receiver module firmware.

A corresponding change is also needed in the qmk firmware, in `keyboards/mitosis/config.h`:

```
-#define SERIAL_UART_BAUD 1000000
+#define SERIAL_UART_BAUD 250000
```